### PR TITLE
Drop jekyll-press plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This is the Jekyll source for the [glfw.org](https://www.glfw.org/) website.
 It requires Jekyll and several other Ruby gems to build.
 
  - jekyll
- - jekyll-press
  - less
  - rouge
  - therubyracer

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,3 @@
 permalink: /:title.html
 highlighter: rouge
 exclude: [README.md]
-
-jekyll-press:
-  exclude: '' # Exclude files from processing - file name, glob pattern or array of file names and glob patterns
-  js_options: {}      # js minifier options
-  css_options: {}     # css minifier options
-  html_options: {}    # html minifier options

--- a/_plugins/jekyll_press.rb
+++ b/_plugins/jekyll_press.rb
@@ -1,5 +1,0 @@
-# Jekyll automated html, css and js minifier plugin
-#
-# Installation note : gem install jekyll-press
-
-require 'jekyll-press'


### PR DESCRIPTION
Mentioned plugin isn't maintained anymore and doesn't work with newer Jekyll versions.