### PR TITLE
Add Fortran bindings to the community list

### DIFF
--- a/community.md
+++ b/community.md
@@ -49,6 +49,7 @@ know](https://github.com/glfw/website/issues) if one should be added or removed.
 | Dart        | Harry Stern         | [dart-glfw](https://github.com/google/dart-glfw) |
 | Delphi      | Erik van Bilsen     | [DelphiGlfw](https://github.com/neslib/DelphiGlfw) |
 | Duktape     | Laurent Zubiaur     | [duk-glfw](https://github.com/lzubiaur/duk-glfw) |
+| Fortran     | Gaétan J.A.M. Jalin | [GLF90W](https://github.com/AarnoldGad/glf90w) |
 | Go          | Coşku Baş           | [glfw](https://github.com/go-gl/glfw) |
 | Haskell     | Brian Lewis         | [GLFW-b](https://github.com/bsl/GLFW-b) |
 | Java        | Nathan Sweet        | [jglfw](https://github.com/badlogic/jglfw) |


### PR DESCRIPTION
Hello,

I have been working on [Fortran 2018+ bindings for GLFW 3.4](https://github.com/AarnoldGad/glf90w) that I would like to add to the community list.
The binding fully supports GLFW 3.4.

Thank you!

G. Jalin