### PR TITLE
Add C# binding DotGLFW

### DIFF
--- a/community.md
+++ b/community.md
@@ -35,6 +35,7 @@ know](https://github.com/glfw/website/issues) if one should be added or removed.
 | Ada         | Felix Krause        | [OpenGLAda](https://github.com/flyx/OpenGLAda) |
 | Beef        | MineGame159         | [Glfw-Beef](https://github.com/MineGame159/glfw-beef) |
 | C++         | Cvelth              | [VKFW](https://github.com/Cvelth/vkfw) |
+| C#          | dcronqvist          | [DotGLFW](https://github.com/dcronqvist/DotGLFW) |
 | C#          | Eric Freed          | [GLFW.NET](https://github.com/ForeverZer0/glfw-net) |
 | C#          | Andy Korth          | [Pencil.Gaming](https://github.com/andykorth/Pencil.Gaming) |
 | C#          | Ruben Labruyere     | [Arqan](https://github.com/TheBoneJarmer/Arqan) |


### PR DESCRIPTION
Hello!

I am the creator and maintainer of [DotGLFW](https://github.com/dcronqvist/DotGLFW), and I wish for it to be added to the bindings at https://www.glfw.org/community.html.

`C# | dcronqvist | DotGLFW`

The library consists of two parts: 
- an unmanaged API that is automatically generated from the GLFW documentation
- a managed API (that is more .NET-y) that is a wrapper around the unmanaged API with compile-time marshalling of everything to support native AOT compilation with .NET.

Includes example to help users get started easily!

//dcronqvist :)