### PR TITLE
Request adding `vulkan4j` to community frameworks.

### DIFF
--- a/community.md
+++ b/community.md
@@ -98,6 +98,7 @@ one should be added or removed.
 | [Falcor](https://developer.nvidia.com/falcor)                                | C++      | [GitHub](https://github.com/nvidiagameworks/falcor)          |
 | [libGDX](https://libgdx.com/)                                                | Java     | [GitHub](https://github.com/libgdx/libgdx/)                  |
 | [LWJGL](https://www.lwjgl.org/)                                              | Java     | [GitHub](https://github.com/LWJGL/lwjgl3/)                   |
+| [Vulkan4j](https://vulkan4j.doki7.club/)                                     | Java     | [GitHub](https://github.com/chuigda/vulkan4j/)               |
 | [nCine](https://ncine.github.io/)                                            | C++      | [GitHub](https://github.com/nCine/nCine)                     |
 | [NimGL](https://nimgl.dev)                                                   | Nim      | [GitHub](https://github.com/nimgl/nimgl)                     |
 | [openFrameworks](https://openframeworks.cc/)                                 | C++      | [GitHub](https://github.com/openframeworks/openFrameworks/)  |


### PR DESCRIPTION
`vulkan4j` is a project aiming at providing Java bindings for computer graphics APIs using Java 22 FFM (Foreign Function and Memory) APIs. This project was initially created only for Vulkan, but soon the initiator realized that it could be extended to other graphics APIs as well.

Currently, GLFW 3.4 is supported.